### PR TITLE
Update accepted automake versions

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -86,6 +86,9 @@ elif (automake-1.13 --version) < /dev/null > /dev/null 2>&1; then
 elif (automake-1.14 --version) < /dev/null > /dev/null 2>&1; then
    AUTOMAKE=automake-1.14
    ACLOCAL=aclocal-1.14
+elif (automake-1.15 --version) < /dev/null > /dev/null 2>&1; then
+   AUTOMAKE=automake-1.15
+   ACLOCAL=aclocal-1.15
 else
     echo
     echo "  You must have automake 1.6 or newer installed to compile $PROJECT."


### PR DESCRIPTION
I had automake-1.15... the file only covered up to 1.14. Without this change, builds on systems with automate newer than 1.14 fail with an error message that automake is too old!